### PR TITLE
Update zc-lambda.md

### DIFF
--- a/docs/build/reference/zc-lambda.md
+++ b/docs/build/reference/zc-lambda.md
@@ -17,7 +17,9 @@ The **`/Zc:lambda`** compiler option enables conforming lambda grammar and proce
 
 The **`/Zc:lambda`** compiler option enables the conforming lambda processor. It parses and implements lambda code according to the C++ standard. This option is off by default, which uses the legacy lambda processor. Use this option to enable conformance-mode syntax checks of generic lambdas when you use the default [`/std:c++14`](std-specify-language-standard-version.md) or the [`/std:c++17`](std-specify-language-standard-version.md) compiler options.
 
-**`/Zc:lambda`** is automatically enabled by the [`/std:c++20`](std-specify-language-standard-version.md), [`/std:c++latest`](std-specify-language-standard-version.md), and [`/experimental:module`](experimental-module.md) options. You can disable it explicitly by using **`/Zc:lambda-`**. The [`/permissive-`](permissive-standards-conformance.md) option doesn't enable **`/Zc:lambda`**.
+**`/Zc:lambda`** is automatically enabled by the [`/std:c++20`](std-specify-language-standard-version.md), [`/std:c++latest`](std-specify-language-standard-version.md), and [`/experimental:module`](experimental-module.md) options. You can disable it explicitly by using **`/Zc:lambda-`**.
+
+Starting with Visual Studio 2022 17.2 the [`/permissive-`](permissive-standards-conformance.md) option also enables **`/Zc:lambda`**. In earlier versions the [`/permissive-`](permissive-standards-conformance.md) option does not enable **`/Zc:lambda`**.
 
 The **`/Zc:lambda`** option is available starting in Visual Studio 2019 version 16.8. It's available as **`/experimental:newLambdaProcessor`** starting in Visual Studio 2019 version 16.3, but this spelling is now deprecated.
 


### PR DESCRIPTION
Update the description of '/Zc:lambda' to indicate that starting with Visual Studio 2022 17.2 '/permissive-' also implies '/Zc:lambda'